### PR TITLE
change local access info

### DIFF
--- a/ibl-frontend/frontend-content/src/app/overview/overview.component.html
+++ b/ibl-frontend/frontend-content/src/app/overview/overview.component.html
@@ -33,7 +33,7 @@
             <br />
             The content of this portal reflects the behavioral data associated with 198 mice up until 2020-03-23, as used in 
             <a target="_blank" href="https://doi.org/10.1101/2020.01.17.909838">The International Brain Laboratory et al. 2020</a>, plus the 
-            behavioral data associated with the newly released 4 electrophysiology recording.
+            behavioral data associated with the newly released 4 electrophysiology recordings.
           </li>
         </ol>
       </div>
@@ -59,18 +59,14 @@
               </ol>
             </li>
             <br>
-            <li><b>Access the database locally with <a target="_blank" href="https://datajoint.io">DataJoint</a>.</b>
+            <li><b>Access the database locally with <a target="_blank" href="https://datajoint.org">DataJoint</a>.</b>
               <ol style="list-style-type: lower-roman">
-                <li>Login to the <a target="_blank" href="https://jupyterhub.internationalbrainlab.org">JupyterHub</a> with your GitHub account as above.</li>
-                <li>Go to <span class="code-style">public_notebooks/Explore IBL pipeline/04-Access the database locally</span> and follow the instructions to obtain DataJoint credentials.</li>
-                <li>Follow the <a target="_blank" href="https://github.com/int-brain-lab/paper-behavior/blob/master/README.md">instructions on GitHub</a> to set up your local environment.</li>
-                <li>You can now run locally all the <a href="https://github.com/int-brain-lab/paper-behavior/blob/master/README.md#how-to-run-the-code" target="_blank">scripts</a> that 
-                  produce the figures in <a target="_blank" href="https://doi.org/10.1101/2020.01.17.909838">The International Brain Laboratory et al. 2020</a>.</li>
+                <li>See detailed instructions on <a href="https://int-brain-lab.github.io/iblenv/public_docs/public_datajoint.html" target="_blank">accessing the database locally</a></li>
               </ol>
             </li>
             <br>
-            <li>You can also simply <b>do a local download through your web browser</b> as explained in the <a href="https://github.com/int-brain-lab/paper-behavior/blob/master/README.md#download-data-without-any-code" target="_blank">
-              instructions on GitHub</a></li>
+            <li>You may also directly download the data through your web browser without running any code. Simply load an internet browser and use the provided link from the <a href="http://ibl.flatironinstitute.org/public/behavior_paper_data.zip" target="_blank"><b>Behavior paper data URL</b></a>
+            </li>
             <br>
           </ol>
         </li>


### PR DESCRIPTION
The link in the "Access the database locally with DataJoint" section will eventually point to the detailed instructions once the `iblenv` folks merge the PR there.